### PR TITLE
ref #7 update add subcommand for adding a repository to the multiple groups

### DIFF
--- a/add/add.go
+++ b/add/add.go
@@ -56,7 +56,7 @@ func (add *AddCommand) addRepositoryToGroup(db *common.Database, groupName strin
 	if err1 := checkDuplication(db, id, absPath); err1 != nil {
 		return append(list, err1)
 	} else {
-		var remotes, err2 = findRemotes(absPath)
+		var remotes, err2 = FindRemotes(absPath)
 		if err2 != nil {
 			return append(list, err2)
 		}
@@ -85,7 +85,7 @@ func (add *AddCommand) AddRepositoriesToGroup(db *common.Database, args []string
 /*
 FindRemotes function returns the remote of the given git repository.
 */
-func findRemotes(path string) ([]common.Remote, error) {
+func FindRemotes(path string) ([]common.Remote, error) {
 	r, err := git.PlainOpen(path)
 	if err != nil {
 		return nil, err

--- a/add/add_cmd.go
+++ b/add/add_cmd.go
@@ -44,7 +44,7 @@ func (add *AddCommand) showError(errorlist []error, onError string) {
 func (add *AddCommand) perform(db *common.Database, args []string, groupName string) int {
 	var onError = db.Config.GetValue(common.RrhOnError)
 
-	var errorlist = add.addRepositoriesToGroup(db, args, groupName)
+	var errorlist = add.AddRepositoriesToGroup(db, args, groupName)
 
 	add.showError(errorlist, onError)
 
@@ -73,7 +73,7 @@ func (add *AddCommand) Run(args []string) int {
 	var db, err2 = common.Open(config)
 	if err2 != nil {
 		fmt.Println(err2.Error())
-		return 1
+		return 2
 	}
 	return add.perform(db, opt.args, opt.group)
 }
@@ -85,17 +85,15 @@ type addOptions struct {
 
 func (add *AddCommand) parse(args []string, config *common.Config) (*addOptions, error) {
 	var opt = addOptions{}
+	var defaultGroup = config.GetValue(common.RrhDefaultGroupName)
 	flags := flag.NewFlagSet("add", flag.ContinueOnError)
 	flags.Usage = func() { fmt.Println(add.Help()) }
-	flags.StringVar(&opt.group, "g", config.GetValue(common.RrhDefaultGroupName), "target group")
-	flags.StringVar(&opt.group, "group", config.GetValue(common.RrhDefaultGroupName), "target group")
+	flags.StringVar(&opt.group, "g", defaultGroup, "target group")
+	flags.StringVar(&opt.group, "group", defaultGroup, "target group")
 	if err := flags.Parse(args); err != nil {
 		return nil, err
 	}
 	opt.args = flags.Args()
-	if opt.group == "" {
-		opt.group = config.GetValue(common.RrhDefaultGroupName)
-	}
 
 	return &opt, nil
 }

--- a/add/add_test.go
+++ b/add/add_test.go
@@ -70,3 +70,28 @@ func TestAddCommand_Run(t *testing.T) {
 		}
 	})
 }
+
+func TestAddToDifferentGroup(t *testing.T) {
+	os.Setenv(common.RrhConfigPath, "../testdata/config.json")
+	os.Setenv(common.RrhDatabasePath, "../testdata/tmp.json")
+	rollback(func() {
+		var command, _ = AddCommandFactory()
+		command.Run([]string{"../testdata/fibonacci"})
+		command.Run([]string{"-g", "group1", "../testdata/fibonacci"})
+
+		var config = common.OpenConfig()
+		var db, _ = common.Open(config)
+		if !db.HasGroup("no-group") {
+			t.Error("no-group: group not found")
+		}
+		if !db.HasRepository("fibonacci") {
+			t.Error("fibonacci: repository not found")
+		}
+		if !db.HasRelation("no-group", "fibonacci") {
+			t.Error("no-group, and fibonacci: the relation not found")
+		}
+		if !db.HasRelation("group1", "fibonacci") {
+			t.Error("group1 and fibonacci: the relation not found")
+		}
+	})
+}

--- a/clone/clone.go
+++ b/clone/clone.go
@@ -17,8 +17,7 @@ func (clone *CloneCommand) toDir(db *common.Database, url string, dest string, r
 	var cmd = exec.Command("git", "clone", url, dest)
 	var err = cmd.Run()
 	if err != nil {
-		fmt.Printf("clone error: %s\n", err.Error())
-		return nil, err
+		return nil, fmt.Errorf("%s: clone error (%s)", url, err.Error())
 	}
 
 	path, err := filepath.Abs(dest)

--- a/clone/clone_cmd.go
+++ b/clone/clone_cmd.go
@@ -79,15 +79,18 @@ func (clone *CloneCommand) perform(db *common.Database, arguments []string) int 
 		}
 	}
 	db.StoreAndClose()
+	printResult(count, clone.Options.dest, clone.Options.group)
+	return 0
+}
+
+func printResult(count int, dest string, group string) {
 	if count == 1 {
-		fmt.Printf("a repository cloned into %s and registered to group %s\n", clone.Options.dest, clone.Options.group)
+		fmt.Printf("a repository cloned into %s and registered to group %s\n", dest, group)
 	} else if count > 1 {
-		fmt.Printf("%d repositories cloned into %s and registered to group %s\n", count, clone.Options.dest, clone.Options.group)
+		fmt.Printf("%d repositories cloned into %s and registered to group %s\n", count, dest, group)
 	} else if count == 0 {
 		fmt.Println("no repositories cloned")
 	}
-
-	return 0
 }
 
 func (clone *CloneCommand) parse(args []string, config *common.Config) ([]string, error) {

--- a/clone/clone_cmd.go
+++ b/clone/clone_cmd.go
@@ -64,7 +64,7 @@ func (clone *CloneCommand) Run(args []string) int {
 	db, err := common.Open(config)
 	if err != nil {
 		fmt.Println(err.Error())
-		return 1
+		return 2
 	}
 	return clone.perform(db, arguments)
 }
@@ -81,8 +81,10 @@ func (clone *CloneCommand) perform(db *common.Database, arguments []string) int 
 	db.StoreAndClose()
 	if count == 1 {
 		fmt.Printf("a repository cloned into %s and registered to group %s\n", clone.Options.dest, clone.Options.group)
-	} else {
+	} else if count > 1 {
 		fmt.Printf("%d repositories cloned into %s and registered to group %s\n", count, clone.Options.dest, clone.Options.group)
+	} else if count == 0 {
+		fmt.Println("no repositories cloned")
 	}
 
 	return 0

--- a/clone/clone_cmd.go
+++ b/clone/clone_cmd.go
@@ -84,12 +84,13 @@ func (clone *CloneCommand) perform(db *common.Database, arguments []string) int 
 }
 
 func printResult(count int, dest string, group string) {
-	if count == 1 {
-		fmt.Printf("a repository cloned into %s and registered to group %s\n", dest, group)
-	} else if count > 1 {
-		fmt.Printf("%d repositories cloned into %s and registered to group %s\n", count, dest, group)
-	} else if count == 0 {
+	switch count {
+	case 0:
 		fmt.Println("no repositories cloned")
+	case 1:
+		fmt.Printf("a repository cloned into %s and registered to group %s\n", dest, group)
+	default:
+		fmt.Printf("%d repositories cloned into %s and registered to group %s\n", count, dest, group)
 	}
 }
 

--- a/clone/clone_test.go
+++ b/clone/clone_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tamada/rrh/common"
@@ -120,6 +121,34 @@ func TestCloneCommand_SpecifyingId(t *testing.T) {
 			t.Error(message)
 		}
 	})
+}
+
+func TestUnknownOption(t *testing.T) {
+	os.Setenv(common.RrhConfigPath, "../testdata/config.json")
+	os.Setenv(common.RrhDatabasePath, "../testdata/tmp.json")
+	var output, _ = common.CaptureStdout(func() {
+		var clone, _ = CloneCommandFactory()
+		clone.Run([]string{})
+	})
+	var cm = CloneCommand{}
+	if output != cm.Help() {
+		t.Error("no arguments were allowed")
+	}
+}
+
+func TestCloneNotGitRepository(t *testing.T) {
+	os.Setenv(common.RrhConfigPath, "../testdata/config.json")
+	os.Setenv(common.RrhDatabasePath, "../testdata/tmp.json")
+	os.Setenv(common.RrhOnError, "FAIL")
+	var output, _ = common.CaptureStdout(func() {
+		var clone, _ = CloneCommandFactory()
+		clone.Run([]string{"../testdata"})
+	})
+	output = strings.TrimSpace(output)
+	var message = "../testdata: clone error (exit status 128)"
+	if output != message {
+		t.Errorf("wont: %s, got: %s", message, output)
+	}
 }
 
 func TestHelpAndSynopsis(t *testing.T) {


### PR DESCRIPTION
Enable for calling `rrh add` subcommand with one repository to register different groups, repeatedly.
For example, see `TestAddToDifferentGroup` function in `add/add_test.go`