### PR TITLE
update the version of cayman-hugo-theme.

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1,9 +1,12 @@
+{{ define "main" }}
+
 <h1>{{ .Title }}</h1>
 
 {{ .Content }}
 
 <ul>
-{{ range where .Pages.ByPublishDate.Reverse "Section" "post" }}
+{{ $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{ range $pages.ByPublishDate.Reverse }}
   <li>
     {{ $dateFormat := $.Site.Params.dateFormat | default "Jan 2, 2006" }}
     {{ .PublishDate.Format $dateFormat }}
@@ -13,3 +16,4 @@
   </li>        
 {{ end }}
 </ul>
+{{ end }}


### PR DESCRIPTION
By updating the theme of Hugo ([cayman-hugo-theme](https://github.com/zwbetz-gh/cayman-hugo-theme)), the content of top page was not shown.

I move from `layouts/partials/blog-post-list.html` to `layouts/index.html`, and update `layouts/index.html` for adjusting `cayman-hugo-theme/layouts/index.html`.
